### PR TITLE
Fix next "use server" export error

### DIFF
--- a/app/actions/procedures.ts
+++ b/app/actions/procedures.ts
@@ -267,4 +267,4 @@ export async function updateProcedureMetaFromForm(formData: FormData) {
   revalidatePath("/gestiones");
 }
 
-export { moveToStatus, moveToStage, toggleTag } from "@/app/gestiones/kanban-actions";
+

--- a/app/gestiones/KanbanBoard.tsx
+++ b/app/gestiones/KanbanBoard.tsx
@@ -14,7 +14,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { toggleTag } from "@/app/actions/procedures";
+import { moveToStatus, moveToStage, toggleTag } from "@/app/gestiones/kanban-actions";
 import Chip from "@/components/ui/Chip";
 
 export type KanbanCard = {


### PR DESCRIPTION
Fix Next.js 'Only async functions are allowed to be exported in a "use server" file' error by removing re-exports and direct importing.

---
<a href="https://cursor.com/background-agent?bcId=bc-af0b814d-d016-476f-b560-541dddf1b138">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af0b814d-d016-476f-b560-541dddf1b138">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

