### PR TITLE
feat(kanban): cross-column DnD, sticky lanes, keep view=kanban in filters, and glass polish

### DIFF
--- a/app/gestiones/page.tsx
+++ b/app/gestiones/page.tsx
@@ -101,12 +101,17 @@ export default async function GestionesPage({
 }) {
   const filters = parseFilters(searchParams);
   const view = searchParams.view === "kanban" ? "kanban" : "list";
-  const kanbanMode = searchParams.mode === "etapas" ? "etapas" : "estado";
+  const selectedTypes = filters.type?.split(",").filter(Boolean) ?? [];
+  const defaultMode = selectedTypes.length === 1 ? "etapas" : "estado";
+  const kanbanMode =
+    searchParams.mode === "etapas" || searchParams.mode === "estado"
+      ? (searchParams.mode as "etapas" | "estado")
+      : defaultMode;
 
   const clients = await prisma.client.findMany({ orderBy: { name: "asc" } });
 
   if (view === "kanban") {
-    const data = await getKanbanData(searchParams);
+    const data = await getKanbanData({ ...searchParams, mode: kanbanMode });
     return (
       <main className="space-y-6">
         <Toast />


### PR DESCRIPTION
## Summary
- add lane droppables and cross-column drag & drop with dnd-kit
- keep Kanban view when applying filters and auto-switch mode based on type
- default Kanban mode to stages when a single type filter is selected

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Parameter implicitly has an 'any' type; Type 'ProcedureWhereInput | ProcedureWhereInput[]' must have a '[Symbol.iterator]()' method)*

------
https://chatgpt.com/codex/tasks/task_e_68a89fdaed10832fa5d93f4148394d3e